### PR TITLE
pass all admin/tweets tests

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -15,25 +15,8 @@ const adminController = {
     return res.render('admin/signin')
   },
   signin: (req, res) => {
-    // 檢查必要資料
-    if (!req.body.account || !req.body.password) {
-      return res.redirect('/admin/signin')
-    }
-    // 檢查 user 是否存在與密碼是否正確
-    let username = req.body.account
-    let password = req.body.password
-
-    User.findOne({ where: { account: username } }).then(user => {
-      if (!user) return res.status(401).redirect('/admin/signin')
-      if (!bcrypt.compareSync(password, user.password)) {
-        return res.status(401).redirect('/admin/signin')
-      }
-      if (user.role !== 'admin') return res.status(401).redirect('/admin/signin')
-      // 簽發 token
-      let payload = { id: user.id }
-      let token = jwt.sign(payload, process.env.JWT_SECRET)
-      return res.redirect('/admin/tweets')
-    }).catch(err => console.log(err))
+    req.flash('success_messages', '登入成功')
+    res.redirect('/admin/tweets')
   },
   getTweets: (req, res) => {
     Tweet.findAll({

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -4,9 +4,9 @@ const Op = Sequelize.Op;
 const bcrypt = require('bcryptjs')
 const db = require('../models')
 const User = db.User //input the user schema
-const Tweet = db.Tweet 
+const Tweet = db.Tweet
 const Reply = db.Reply
-const Like  = db.Like
+const Like = db.Like
 
 const userController = {
 
@@ -85,43 +85,43 @@ const userController = {
             return res.redirect('back')
         }
 
-        User.findOne({ where: { id: {[Op.ne]: req.user.id}, email: req.body.email } }).then(mailuser => {
+        User.findOne({ where: { id: { [Op.ne]: req.user.id }, email: req.body.email } }).then(mailuser => {
             if (mailuser) {
                 req.flash('error_messages', '信箱重複！')
                 return res.redirect('back')
             } else {
-                User.findOne({ where: { id: {[Op.ne]: req.user.id}, account: req.body.account } }).then(user => {
+                User.findOne({ where: { id: { [Op.ne]: req.user.id }, account: req.body.account } }).then(user => {
                     if (user) {
                         req.flash('error_messages', '帳號重複！')
                         return res.redirect('back')
                     } else {
                         if (!req.body.password) {
                             return User.findByPk(req.user.id)
-                            .then((user) => {
-                            user.update({
-                                account: req.body.account,
-                                name: req.body.name,
-                                email: req.body.email,
-                            })
                                 .then((user) => {
-                                req.flash('success_messages', 'setting infomation was successfully to update')
-                                res.redirect('setting')
+                                    user.update({
+                                        account: req.body.account,
+                                        name: req.body.name,
+                                        email: req.body.email,
+                                    })
+                                        .then((user) => {
+                                            req.flash('success_messages', 'setting infomation was successfully to update')
+                                            res.redirect('setting')
+                                        })
                                 })
-                            })
                         } else {
                             return User.findByPk(req.user.id)
-                            .then((user) => {
-                            user.update({
-                                account: req.body.account,
-                                name: req.body.name,
-                                email: req.body.email,
-                                password: bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null)
-                            })
                                 .then((user) => {
-                                req.flash('success_messages', 'setting infomation was successfully to update')
-                                res.redirect('setting')
+                                    user.update({
+                                        account: req.body.account,
+                                        name: req.body.name,
+                                        email: req.body.email,
+                                        password: bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null)
+                                    })
+                                        .then((user) => {
+                                            req.flash('success_messages', 'setting infomation was successfully to update')
+                                            res.redirect('setting')
+                                        })
                                 })
-                            })
                         }
                     }
                 })
@@ -135,15 +135,15 @@ const userController = {
     getUserProfile: async (req, res) => {
         let profileUser = await User.findByPk(req.params.id, {
             include: [
-                { model: Reply, include: [Tweet]},
-                { model: Tweet, include: [User, Like, Reply]},
+                { model: Reply, include: [Tweet] },
+                { model: Tweet, include: [User, Like, Reply] },
                 { model: User, as: 'Followers' },
                 { model: User, as: 'Followings' },
             ]
-            })
+        })
         profileUser = profileUser.dataValues
         const isFollowed = req.user.Followings.map(d => d.id).includes(profileUser.id)
-        return res.render('userProfile', {profileUser, isFollowed})
+        return res.render('userProfile', { profileUser, isFollowed })
     },
 }
 

--- a/middleware/check-auth.js
+++ b/middleware/check-auth.js
@@ -4,16 +4,18 @@ module.exports = {
   authenticatedUser: (req, res, next) => {
     if (helpers.ensureAuthenticated(req)) {
       if (helpers.getUser(req).role === "") { return next() }
-      req.flash('error_messages', 'admin帳號無法登入...')
-    } 
+      req.flash('error_messages', '管理者帳號後台登入')
+      return res.redirect('/admin/tweets')
+    }
     return res.redirect('/signin')
   },
 
   authenticatedAdmin: (req, res, next) => {
     if (helpers.ensureAuthenticated(req)) {
       if (helpers.getUser(req).role === 'admin') { return next() }
-      req.flash('error_messages', 'user帳號無法登入...')
-    } 
+      req.flash('error_messages', '使用者帳號前台登入')
+      return res.redirect('/tweets')
+    }
     return res.redirect('/admin/signin')
   },
 

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -14,15 +14,15 @@ const { authenticatedUser, authenticatedAdmin, isOwnProfile, editOwnProfile } = 
 const passport = require('../config/passport')
 const user = require('../models/user.js')
 
-// const authenticated = passport.authenticate('jwt', { session: false })
+
 
 
 ///////
 // admin
 ///////
 router.get('/admin/signin', adminController.signinPage)
-router.post('/admin/signin', authenticatedAdmin, adminController.signin)
-router.get('/admin/tweets', passport.authenticate('jwt', { session: false }), authenticatedAdmin, adminController.getTweets)
+router.post('/admin/signin', passport.authenticate('local', { failureRedirect: '/admin/signin', failureFlash: true }), authenticatedAdmin, adminController.signin)
+router.get('/admin/tweets', authenticatedAdmin, adminController.getTweets)
 router.delete('/admin/tweets/:id', authenticatedAdmin, adminController.deleteTweet)
 router.get('/admin/users', authenticatedAdmin, adminController.getUsers)
 


### PR DESCRIPTION
因為admin. tweets test 有一個是管理者到前台登入，最後要導回admin/tweets頁面才能通過。
所以將 authenticatedUser，若管理者登入，錯誤訊息和導向頁面改為如下：
  
req.flash('error_messages', '管理者帳號後台登入')
return res.redirect('/admin/tweets')

之所以寫，'管理者帳號後台登入'，是因為如果該管理者已經是登入過了，就可以直接進入並看到/admin/tweets畫面。
如果還未登入就會因/admin/tweets也有權限擋著，而到admin/signin頁面。
如果不同情況導入不同flash訊息，可能有點複雜，所以用兩者都可以適用的敘述。如果覺得字句需要改，歡迎提出喔！

同理，authenticatedAdmin我也修改了一下：
      req.flash('error_messages', '使用者帳號前台登入')
      return res.redirect('/tweets')
